### PR TITLE
213/improve exception handling

### DIFF
--- a/src/main/java/Backend/Drifty.java
+++ b/src/main/java/Backend/Drifty.java
@@ -61,21 +61,20 @@ public class Drifty {
      */
     public void start() {
         Utility utility = new Utility(messageBroker);
-        boolean errorFlag = false;
         messageBroker.sendMessage("Validating the link...", DriftyConstants.LOGGER_INFO, "link");
         if (url.contains(" ")) {
             messageBroker.sendMessage("Link should not contain whitespace characters!", DriftyConstants.LOGGER_ERROR, "link");
-            errorFlag = true;
+            return;
         } else if (url.length() == 0) {
             messageBroker.sendMessage("Link cannot be empty!", DriftyConstants.LOGGER_ERROR, "link");
-            errorFlag = true;
+            return;
         } else {
             try {
                 Utility.isURLValid(url);
                 messageBroker.sendMessage("Link is valid!", DriftyConstants.LOGGER_INFO, "link");
             } catch (Exception e) {
                 messageBroker.sendMessage(e.getMessage(), DriftyConstants.LOGGER_ERROR, "link");
-                errorFlag = true;
+                return;
             }
         }
 
@@ -90,7 +89,7 @@ public class Drifty {
                     new CheckDirectory(downloadsFolder);
                 } catch (IOException e) {
                     messageBroker.sendMessage(e.getMessage(), DriftyConstants.LOGGER_ERROR, "directory");
-                    errorFlag = true;
+                    return;
                 }
             }
         }
@@ -99,13 +98,11 @@ public class Drifty {
             fileName = utility.findFilenameInLink(url);
             if (fileName == null || fileName.length() == 0) {
                 messageBroker.sendMessage("Filename cannot be empty!", DriftyConstants.LOGGER_ERROR, "Filename");
-                errorFlag = true;
+                return;
             }
         }
 
-        if (!errorFlag) {
-            new FileDownloader(url, fileName, downloadsFolder).run();
-        }
+        new FileDownloader(url, fileName, downloadsFolder).run();
     }
 
     /**

--- a/src/main/java/Backend/FileDownloader.java
+++ b/src/main/java/Backend/FileDownloader.java
@@ -143,6 +143,8 @@ public class FileDownloader implements Runnable {
 
             } catch (SecurityException e) {
                 messageBroker.sendMessage("Write access to " + dir + fileName + " denied !", LOGGER_ERROR, "download");
+            } catch (FileNotFoundException fileNotFoundException) {
+                messageBroker.sendMessage(FILENOTFOUND, LOGGER_ERROR, "download");
             } catch (IOException e) {
                 messageBroker.sendMessage(FAILED_TO_DOWNLOAD_CONTENTS, LOGGER_ERROR, "download");
             }
@@ -284,6 +286,14 @@ public class FileDownloader implements Runnable {
                             messageBroker.sendMessage(USER_INTERRUPTION, LOGGER_ERROR, "download");
                         } catch (IOException io1) {
                             messageBroker.sendMessage(FAILED_TO_DOWNLOAD_YOUTUBE_VIDEO, LOGGER_ERROR, "download");
+                            String message = e.getMessage();
+                            String[] messageArray = message.split(",");
+                            if(messageArray.length >= 1 && messageArray[1].toLowerCase().trim().replaceAll(" ", "").equals("permissiondenied")) {
+                                messageBroker.sendMessage(PERMISSIONDENIED_YOUTUBE_VIDEO, LOGGER_ERROR, "download");
+                            }
+                            else {
+                                System.out.println(e.getMessage());
+                            }
                         }
                     } catch (IOException io) {
                         messageBroker.sendMessage(FAILED_TO_INITIALISE_YOUTUBE_VIDEO, LOGGER_ERROR, "download");

--- a/src/main/java/CLI/Drifty_CLI.java
+++ b/src/main/java/CLI/Drifty_CLI.java
@@ -143,7 +143,7 @@ public class Drifty_CLI {
                 }
                 if ((fileName == null || (fileName.length() == 0)) && (!isYoutubeURL)) {
                     System.out.print(ENTER_FILE_NAME_WITH_EXTENSION);
-                    fileName = SC.nextLine();
+                    fileName = SC.next();
                 } else {
                     if (isYoutubeURL) {
                         System.out.print("Do you like to use the video title as the filename? (Enter Y for yes and N for no) : ");
@@ -153,7 +153,7 @@ public class Drifty_CLI {
                     SC.nextLine(); // To remove 'whitespace' from input buffer.
                     String choiceString = SC.nextLine();
                     boolean choice = utility.yesNoValidation(choiceString, RENAME_FILE);
-                    if (!choice) {
+                    if (choice) {
                         System.out.print(ENTER_FILE_NAME_WITH_EXTENSION);
                         fileName = SC.nextLine();
                     }

--- a/src/main/java/CLI/Drifty_CLI.java
+++ b/src/main/java/CLI/Drifty_CLI.java
@@ -146,7 +146,7 @@ public class Drifty_CLI {
                     fileName = SC.next();
                 } else {
                     if (isYoutubeURL) {
-                        System.out.print("Do you like to use the video title as the filename? (Enter Y for yes and N for no) : ");
+                        System.out.print(RENAME_VIDEO_TITLE);
                     } else {
                         System.out.print(RENAME_FILE);
                     }

--- a/src/main/java/Utils/DriftyConstants.java
+++ b/src/main/java/Utils/DriftyConstants.java
@@ -19,7 +19,7 @@ public final class DriftyConstants {
     public static final String CLI_APPLICATION_TERMINATED = "Drifty CLI (Command Line Interface) Application Terminated!";
     public static final String GUI_APPLICATION_TERMINATED = "Drifty GUI (Graphical User Interface) Application Terminated!";
     public static final String INVALID_LINK = "Invalid Link!";
-    public static final String AUTO_FILE_NAME_DETECTION_FAILED = "Either file name or the extension was missing in the url. The url must be of the form https://www.example.com/fileName.extension";
+    public static final String AUTO_FILE_NAME_DETECTION_FAILED = "An error occurred! Either the file name or the extension was missing in the url. The url must be of the form https://www.example.com/fileName.extension.";
     public static final String TRYING_TO_AUTO_DETECT_DOWNLOADS_FOLDER = "Trying to automatically detect default Downloads folder...";
     public static final String TRYING_TO_DOWNLOAD_FILE = "Trying to download the file ...";
     public static final String HELP_FLAG = "-help";
@@ -38,6 +38,7 @@ public final class DriftyConstants {
     public static final String WINDOWS_OS_NAME = "Windows";
     public static final String USER_HOME_PROPERTY = "user.home";
     public static final String RENAME_FILE = "Would you like to rename this file? (Enter Y for yes and N for no) : ";
+    public static final String RENAME_VIDEO_TITLE = "Would you like to rename the video title? (Enter Y for yes and N for no) : ";
     public static final String QUIT_OR_CONTINUE = "Press Q to Quit Or Press any Key to Continue";
     public static final String FAILED_TO_RETRIEVE_DEFAULT_DOWNLOAD_FOLDER = "Failed to retrieve default download folder!";
     public static final String FAILED_TO_CONNECT_TO_URL = "Failed to connect to ";
@@ -55,11 +56,13 @@ public final class DriftyConstants {
     public static final String DIRECTORY_CREATED = "Directory Created";
     public static final String ERROR_WHILE_CHECKING_FOR_DIRECTORY = "Error while checking for directory !";
 
+    public static final String FILENOTFOUND = "An error occurred! Requested file does not exist, please check the file name and the extension.";
     public static final String FAILED_TO_DOWNLOAD = "Failed to download ";
     public static final String FAILED_TO_DOWNLOAD_CONTENTS = "Failed to download the contents ! ";
     public static final String FAILED_TO_READ_DATA_STREAM = "Failed to get I/O operations channel to read from the data stream !";
 
     public static final String FAILED_TO_DOWNLOAD_YOUTUBE_VIDEO = "Failed to download YouTube video!";
+    public static final String PERMISSIONDENIED_YOUTUBE_VIDEO = "You do not have access to download the video, permission is denied.";
     public static final String FAILED_TO_INITIALISE_YOUTUBE_VIDEO = "Failed to initialise YouTube video downloader!";
     public static final String THREAD_ERROR_ENCOUNTERED = "Error: thread encountered an error";
 

--- a/src/main/java/Utils/DriftyConstants.java
+++ b/src/main/java/Utils/DriftyConstants.java
@@ -56,7 +56,7 @@ public final class DriftyConstants {
     public static final String DIRECTORY_CREATED = "Directory Created";
     public static final String ERROR_WHILE_CHECKING_FOR_DIRECTORY = "Error while checking for directory !";
 
-    public static final String FILENOTFOUND = "An error occurred! Requested file does not exist, please check the file name and the extension.";
+    public static final String FILENOTFOUND = "An error occurred! Requested file does not exist, please check the url.";
     public static final String FAILED_TO_DOWNLOAD = "Failed to download ";
     public static final String FAILED_TO_DOWNLOAD_CONTENTS = "Failed to download the contents ! ";
     public static final String FAILED_TO_READ_DATA_STREAM = "Failed to get I/O operations channel to read from the data stream !";

--- a/src/main/java/Utils/DriftyConstants.java
+++ b/src/main/java/Utils/DriftyConstants.java
@@ -19,7 +19,7 @@ public final class DriftyConstants {
     public static final String CLI_APPLICATION_TERMINATED = "Drifty CLI (Command Line Interface) Application Terminated!";
     public static final String GUI_APPLICATION_TERMINATED = "Drifty GUI (Graphical User Interface) Application Terminated!";
     public static final String INVALID_LINK = "Invalid Link!";
-    public static final String AUTO_FILE_NAME_DETECTION_FAILED = "Automatic file name detection failed!";
+    public static final String AUTO_FILE_NAME_DETECTION_FAILED = "Either file name or the extension was missing in the url. The url must be of the form https://www.example.com/fileName.extension";
     public static final String TRYING_TO_AUTO_DETECT_DOWNLOADS_FOLDER = "Trying to automatically detect default Downloads folder...";
     public static final String TRYING_TO_DOWNLOAD_FILE = "Trying to download the file ...";
     public static final String HELP_FLAG = "-help";
@@ -32,8 +32,8 @@ public final class DriftyConstants {
     public static final String VERSION_FLAG_SHORT = "-v";
     public static final String LOCATION_FLAG_SHORT = "-l";
     public static final String BATCH_FLAG_SHORT = "-b";
-    public static final String ENTER_FILE_NAME_WITH_EXTENSION = "Enter the filename (with file extension) : ";
-    public static final String ENTER_FILE_LINK = "Enter the link to the file : ";
+    public static final String ENTER_FILE_NAME_WITH_EXTENSION = "Please enter the filename with file extension (fileName.extension) you would like to download : ";
+    public static final String ENTER_FILE_LINK = "Enter the link to the file (of the form https://www.example.com/fileName.extension): ";
     public static final String OS_NAME = "os.name";
     public static final String WINDOWS_OS_NAME = "Windows";
     public static final String USER_HOME_PROPERTY = "user.home";


### PR DESCRIPTION
As a part of 213:improveExceptionHandling PR, I have focused to improve user experience by providing more details on error messages and fixing inconsistent behavior. Also I've focused on individual download path only to make sure that PR is small and focused. Following are the changes:
1. The given issue described has been resolved by handling the exception when permission is denied to download a YouTube video. The user is informed with the error message: "You do not have access to download the video, permission is denied." 
2. It is very common that when downloading a file from non YouTube link, the file may not exist. So I'm handling file not found exception explicitly to let the user know with the error message: "An error occurred! Requested file does not exist, please check the file name and the extension."
3. Suppress other messages when an error occurs so the last message printed is the error and the user knows what/how to act upon. This is the reason I’m returning as soon as an error occurs in start() of drifty.java instead of proceeding to the next stage and polluting console with irrelevant messages.
4. For CLI path, the code block prompts the user to rename fileName (to be downloaded from a url which is not a YouTube link) or use the YouTube video title as the fileName. There’s an inconsistency in the question asked as shown below:
a. Rename File prompt: "Would you like to rename this file? (Enter Y for yes and N for no) :"
b. Rename YouTube video: "Do you like to use the video title as the filename? (Enter Y for yes and N for no):"
Renaming file prompt is asking user if they’d like to rename it while the other prompt is asking the user if they’d like to keep the name unchanged. From my personal experience, after experiencing renaming file prompt flow a couple of times, I was expecting similar behavior for YouTube video renaming prompt. That is, would you like to rename it instead of asking me would you like to keep the name as it is. So with a simple prompt (question) change, I’ve tried to fix the inconsistent question (hence the change in Drifty_CLI.java file).
5. Lastly, there was a bug in CLI file download path where if the user didn’t enter fileName and/or the extension, the program is devised to prompt the user to enter fileName with the extension. Although using SC.nextLine was causing the program to proceed without waiting for the user to respond to the "enter fileName" prompt. Hence the change in line#146 of Drifty_CLI.java.

So overall, I’ve focused to improve the user experience by providing detailed error message and fixing inconsistent flow. As a part of testing, I've tested the following scenarios with both CLI and GUI but in future, would like to have test files included as a part of the codebase.
1. Test incorrect URL with incorrect domain name, missing fileName or the extension, missing protocol, etc (non-youtube link).
2. Test with correct URL and having an actual file to download (non-youtube link).
3. Test with YouTube link with insufficient permission to download a video file.
4. Test with a YouTube link with having an access to download a video.